### PR TITLE
recordPageNumber field

### DIFF
--- a/lib/graphqr.rb
+++ b/lib/graphqr.rb
@@ -37,6 +37,7 @@ end
 require 'graphqr/hooks'
 
 require 'graphqr/fields/base_field'
+require 'graphqr/pagination/resolvers/record_page_number_resolver'
 require 'graphqr/pagination/types/pagination_page_info_type'
 require 'graphqr/pagination/pagination_extension'
 

--- a/lib/graphqr/pagination/resolvers/pagy_resolver.rb
+++ b/lib/graphqr/pagination/resolvers/pagy_resolver.rb
@@ -33,7 +33,10 @@ module GraphQR
         end
 
         def page_info
-          @pagy
+          @pagy.tap do |pagy|
+            pagy.class_eval { attr_accessor :ordered_record_ids }
+            pagy.ordered_record_ids = @records&.all? { |r| r&.respond_to?(:id) } ? @records.map(&:id) : []
+          end
         end
       end
     end

--- a/lib/graphqr/pagination/resolvers/record_page_number_resolver.rb
+++ b/lib/graphqr/pagination/resolvers/record_page_number_resolver.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module GraphQR
+  module Pagination
+    module Resolvers
+      ##
+      # This is a resolver that receives the id of an object and returns the page number
+      # in which the object is located.
+      class RecordPageNumberResolver < ::GraphQL::Schema::Resolver
+        INDEX_OFFSET = 1
+
+        type Int, null: true
+
+        argument :record_id, ID, required: true
+
+        def resolve(record_id:)
+          per_page = object.vars[:items]
+          records_ids = object.ordered_record_ids
+          record_index = records_ids.find_index(record_id.to_i)
+
+          return if per_page.zero? || records_ids.blank? || record_index.blank?
+
+          record_position = (record_index + INDEX_OFFSET).to_f
+          (record_position / per_page).ceil
+        end
+      end
+    end
+  end
+end

--- a/lib/graphqr/pagination/types/pagination_page_info_type.rb
+++ b/lib/graphqr/pagination/types/pagination_page_info_type.rb
@@ -25,6 +25,7 @@ module GraphQR
         field :next_page, Int, null: true,
                                method: :next,
                                description: 'The previous page number or nil if there is no previous page'
+        field :record_page_number, resolver: GraphQR::Pagination::Resolvers::RecordPageNumberResolver
       end
     end
   end


### PR DESCRIPTION
## What does this PR do?
Adds `recordPageNumber` field on `pageInfo` type. The field receives `recordId` as argument and returns the page in which the record is present:

1. Record on queried page, when only one page is present:
![image](https://user-images.githubusercontent.com/31138385/73644614-786fa000-4654-11ea-83e2-b6580b2163fd.png)

2. Record on queried page, when multiple pages are present:
![image](https://user-images.githubusercontent.com/31138385/73644634-82919e80-4654-11ea-9bc1-e2c887c67799.png)

3. Record on different page:
![image](https://user-images.githubusercontent.com/31138385/73644654-8b827000-4654-11ea-9249-ba68a16256c5.png)

4. Record not present on any page:
![image](https://user-images.githubusercontent.com/31138385/73644669-93daab00-4654-11ea-9c69-b21402c65d96.png)

