### PR TITLE
Use proc to only execute full query when necessary instead of every call

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,6 @@ Metrics/LineLength:
 
 Metrics/MethodLength:
   Max: 15
+
+Metrics/AbcSize:
+  Max: 16

--- a/lib/graphqr/pagination/resolvers/pagy_resolver.rb
+++ b/lib/graphqr/pagination/resolvers/pagy_resolver.rb
@@ -34,8 +34,8 @@ module GraphQR
 
         def page_info
           @pagy.tap do |pagy|
-            pagy.class_eval { attr_accessor :ordered_record_ids }
-            pagy.ordered_record_ids = @records&.all? { |r| r&.respond_to?(:id) } ? @records.map(&:id) : []
+            pagy.class_eval { attr_accessor :ordered_record_ids_proc }
+            pagy.ordered_record_ids_proc = -> { @records&.all? { |r| r&.respond_to?(:id) } ? @records.map(&:id) : [] }
           end
         end
       end

--- a/lib/graphqr/pagination/resolvers/record_page_number_resolver.rb
+++ b/lib/graphqr/pagination/resolvers/record_page_number_resolver.rb
@@ -15,7 +15,7 @@ module GraphQR
 
         def resolve(record_id:)
           per_page = object.vars[:items]
-          records_ids = object.ordered_record_ids
+          records_ids = object.ordered_record_ids_proc.call
           record_index = records_ids.find_index(record_id.to_i)
 
           return if per_page.zero? || records_ids.blank? || record_index.blank?


### PR DESCRIPTION
The way `ordered_record_ids` was implemented, we were always executing a query to get all records, even when we didn't need it

Using a lamda function, we can delegate the execution to the caller